### PR TITLE
Fix the sorting problem with products filtering page

### DIFF
--- a/js/modules/blocklayered/blocklayered.js
+++ b/js/modules/blocklayered/blocklayered.js
@@ -205,7 +205,7 @@ function reloadContent(paramsPlus) {
   window.ajaxQuery = $.ajax({
     type: 'GET',
     url: window.baseDir + 'modules/blocklayered/blocklayered-ajax.php',
-    data: data + paramsPlus + n,
+	data: data + '&' + paramsPlus + n,
     dataType: 'json',
     cache: false, // @todo see a way to use cache and to add a timestamps parameter to refresh cache each 10 minutes for example
     success: function (result) {


### PR DESCRIPTION
When blocklayered is enabled, the sorting in descending order does not work in the products filtering page.