### PR TITLE
Remove itemprop

### DIFF
--- a/modules/productscategory/productscategory.tpl
+++ b/modules/productscategory/productscategory.tpl
@@ -41,7 +41,7 @@
                 >
               </picture>
             </a>
-            <h5 itemprop="name" class="product-name">
+            <h5 class="product-name">
               <a href="{$link->getProductLink($categoryProduct.id_product, $categoryProduct.link_rewrite, $categoryProduct.category, $categoryProduct.ean13)|escape:'html':'UTF-8'}" title="{$categoryProduct.name|htmlspecialchars}">{$categoryProduct.name|truncate:14:'...'|escape:'html':'UTF-8'}</a>
             </h5>
             {if $ProdDisplayPrice && $categoryProduct.show_price == 1 && !isset($restricted_country_mode) && !$PS_CATALOG_MODE}


### PR DESCRIPTION
This itemprop is causing the Google Structured Data Testing Tool to treat the product as it had many names. On product page products from category land into the main div marked as itemscope itemtype="https://schema.org/Product", and in effect their itemprops add to the main product's scope.