### PR TITLE
Make string translatable

### DIFF
--- a/modules/blocktopmenu/blocktopmenu.tpl
+++ b/modules/blocktopmenu/blocktopmenu.tpl
@@ -1,7 +1,7 @@
 {if $MENU != ''}
     <nav>
         <div id="block_top_menu" class="sf-contener clearfix col-lg-12">
-            <div class="cat-title">{l s="Menu" mod="blocktopmenu"}</div>
+            <div class="cat-title">{l s='Menu' mod='blocktopmenu'}</div>
             <ul class="sf-menu clearfix menu-content">
                 {$MENU}
                 {if $MENU_SEARCH}


### PR DESCRIPTION
mod="module_name" will be ignored by regex. mod='module_name' must be inside single quote.