### PR TITLE
Make the PS_GRID_PRODUCT option work.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -145,7 +145,7 @@ function bindGrid() {
     return;
   }
 
-  var view = $.totalStorage('display');
+  var view = $.totalStorage('display') || (displayList ? 'list' : 'grid');
   display(view);
 
   $(document).on('click', '#grid', function(e) {


### PR DESCRIPTION
The list of products has always been a list if the user first visited it regardless of the value of PS_GRID_PRODUCT.