### PR TITLE
Issue 61 - Quantity discount leads to wrong prices

### DIFF
--- a/js/product.js
+++ b/js/product.js
@@ -968,7 +968,6 @@ function updateDiscountTable(newPrice) {
     var quantity = $(this).data('discount-quantity');
     var discountedPrice;
     var discountUpTo;
-
     if (type === 'percentage') {
       discountedPrice = newPrice * (1 - discount / 100);
       discountUpTo = newPrice * (discount / 100) * quantity;
@@ -976,8 +975,7 @@ function updateDiscountTable(newPrice) {
       discountedPrice = newPrice - discount;
       discountUpTo = discount * quantity;
     }
-
-    if (discountedPrice != 0) {
+    if (displayDiscountPrice != 0 && discountedPrice != 0) {
       $(this).attr('data-real-discount-value', formatCurrency(discountedPrice * currencyRate, currencyFormat, currencySign, currencyBlank));
       $(this).children('td').eq(1).text(formatCurrency(discountedPrice * currencyRate, currencyFormat, currencySign, currencyBlank));
     }


### PR DESCRIPTION
This issue was introduced by commit 6c43f42560871e8d5245ea6f73089c0057df07b3

Quantity discount table is initially rendered correctly, but then it's destroyed by javascript code. Javascript now *always* replace the values with **new price**, even when we are displaying **discount values** 
