### PR TITLE
Added line to remove shipping from the checkout when it is unavailable

### DIFF
--- a/js/cart-summary.js
+++ b/js/cart-summary.js
@@ -762,6 +762,8 @@ function updateCartSummary(json) {
     }
     if (!hasDeliveryAddress)
       $('.cart_total_delivery').hide();
+    if (json.carrier.id == null && !json.free_ship)
+      $('.cart_total_delivery').hide();
   }
 
   if (json.total_wrapping > 0) {


### PR DESCRIPTION
Added line to remove shipping when it is unavailable, happens with logged in users because they usually have address set, therefore carrier is calculated but can be null (e.g. too heavy shipment) fixes thirtybees/thirtybees#963