### PR TITLE
Update history.js

### DIFF
--- a/js/history.js
+++ b/js/history.js
@@ -20,7 +20,7 @@ function showOrder(mode, var_content, file) {
         bindOrderDetailForm();
 
         $blockOrderDetail.fadeIn(function() {
-          $.scrollTo($blockOrderDetail, 1000, {offset: -(50 + 10)});
+          $.scrollTo($blockOrderDetail, 1000, {axis:'y', offset: -(50 + 10)});
         });
       });
     }


### PR DESCRIPTION
As clicking on order details is ment to only scroll down to the section where order details are, there is no need for having enabled x&y axis for scrolling down.,
Such solution provides a permanent fix for theme modifications where one uses following in body (width=100vw; overflow-x: hidden;).
If default, than clicking on order details also moves into x direction for preset Page slider width.